### PR TITLE
Change LevelProgression from number to object with callback

### DIFF
--- a/apps/web/app/campaigns/[campaignId]/characters/[characterId]/page.tsx
+++ b/apps/web/app/campaigns/[campaignId]/characters/[characterId]/page.tsx
@@ -1,5 +1,5 @@
+import { EventCard } from "@/components/event-card";
 import { H4, Muted } from "@/components/ui/typography";
-import { CampaignService } from "services/campaign-service";
 import { CampaignRecord } from "@/db/schema/campaigns";
 import { CharacterRecord } from "@/db/schema/characters";
 import { classToPlain } from "@/lib/class-to-plain";
@@ -7,7 +7,7 @@ import { getCampaign } from "app/campaigns/actions";
 import { CharacterEditor } from "app/characters/components/character-editor";
 import { redirect } from "next/navigation";
 import { Campaign, CampaignEventWithRound, Character, DefaultRuleSet, World } from "roleplayer";
-import { EventCard } from "@/components/event-card";
+import { CampaignService } from "services/campaign-service";
 
 export default async function CampaignCharacterPage({ params: { campaignId: id, characterId: cid } }: { params: { campaignId: string; characterId: string } }) {
   const campaignId = id;
@@ -65,6 +65,7 @@ export default async function CampaignCharacterPage({ params: { campaignId: id, 
           await updateCharacter(campaignId, characterId, update);
           redirect("../");
         }}
+        characterLevel={campaignInstance.getCharacterLevel(characterFromEvents)}
       />
 
       <H4 className="my-2">Events</H4>

--- a/apps/web/app/characters/components/character-editor.tsx
+++ b/apps/web/app/characters/components/character-editor.tsx
@@ -2,25 +2,25 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { ClassSelector } from "./class-selector";
-import { Character, World } from "roleplayer";
-import { useState } from "react";
-import { RemoveFunctions } from "types/without-functions";
-import { CharacterClassEditor } from "./class-editor";
-import { CharacterStatsEditor } from "./character-stats-editor";
-import { CharacterInventoryEditor } from "./character-inventory-editor";
 import { Separator } from "@/components/ui/separator";
 import { H3, H4, Muted, Paragraph } from "@/components/ui/typography";
+import { useState } from "react";
+import { Character, World } from "roleplayer";
+import { RemoveFunctions } from "types/without-functions";
+import { CharacterInventoryEditor } from "./character-inventory-editor";
+import { CharacterStatsEditor } from "./character-stats-editor";
+import { CharacterClassEditor } from "./class-editor";
+import { ClassSelector } from "./class-selector";
 
 type CharacterEditorProps = {
   onSave: (character: RemoveFunctions<Character>) => void;
-  characterFromEvents: RemoveFunctions<Character>;
   world: RemoveFunctions<World>;
+  characterFromEvents: RemoveFunctions<Character>;
+  characterLevel: number;
 };
 
-export function CharacterEditor({ onSave, world, characterFromEvents }: CharacterEditorProps) {
+export function CharacterEditor({ onSave, world, characterFromEvents, characterLevel }: CharacterEditorProps) {
   const [update, setUpdate] = useState(characterFromEvents);
-  const characterLevel = world.ruleset.levelProgression.findIndex((l) => l > update.xp);
 
   return (
     <>

--- a/packages/roleplayer/src/core/actor/character.ts
+++ b/packages/roleplayer/src/core/actor/character.ts
@@ -1,3 +1,4 @@
+import { Campaign } from "../..";
 import { Id } from "../../lib/generate-id";
 import { CampaignEvent, CampaignEventType, CampaignEventWithRound } from "../campaign/campaign-events";
 import { D20, roll } from "../dice/dice";
@@ -67,7 +68,12 @@ export type CharacterClass = {
   classId: Clazz["id"];
 };
 
-export type LevelProgression = number;
+export type LevelProgression = {
+  id: Id;
+  requiredXp: number;
+  unlocksLevel: number;
+  onLevelUp?: (character: Character, publishEvent: Campaign["publishCampaignEvent"]) => void;
+};
 
 export type CharacterEquipmentSlot = {
   item?: Item;

--- a/packages/roleplayer/src/core/campaign/campaign.test.ts
+++ b/packages/roleplayer/src/core/campaign/campaign.test.ts
@@ -1,0 +1,52 @@
+import { DefaultRuleSet } from "../../data/data";
+import { dangerousGenerateId } from "../../lib/generate-id";
+import { World } from "../world/world";
+import { Campaign } from "./campaign";
+import { CampaignEventWithRound } from "./campaign-events";
+
+describe("Campaign", () => {
+  it("calculates correct character level", () => {
+    const characterId = dangerousGenerateId();
+    const events: CampaignEventWithRound[] = [
+      {
+        type: "CharacterSpawned",
+        characterId,
+        id: dangerousGenerateId(),
+        roundId: dangerousGenerateId(),
+        serialNumber: 0,
+      },
+      {
+        type: "CharacterNameSet",
+        characterId,
+        id: dangerousGenerateId(),
+        name: "Some name",
+        roundId: dangerousGenerateId(),
+        serialNumber: 0,
+      },
+      {
+        type: "CharacterMaximumHealthSet",
+        characterId,
+        id: dangerousGenerateId(),
+        roundId: dangerousGenerateId(),
+        maximumHealth: 10,
+        serialNumber: 0,
+      },
+      {
+        type: "CharacterExperienceSet",
+        characterId,
+        experience: 100,
+        id: dangerousGenerateId(),
+        roundId: dangerousGenerateId(),
+        serialNumber: 0,
+      },
+    ];
+
+    const world = new World({ name: "World", ruleset: DefaultRuleSet });
+    const campaign = new Campaign({ id: "0000000-0000-0000-0000-000000000000" as const, name: "Campaign", world, events });
+    const state = campaign.getCampaignStateFromEvents();
+
+    expect(state.characters.length).toBe(1);
+    const character = state.characters[0];
+    expect(campaign.getCharacterLevel(character!)).toBe(3);
+  });
+});

--- a/packages/roleplayer/src/core/campaign/campaign.ts
+++ b/packages/roleplayer/src/core/campaign/campaign.ts
@@ -396,7 +396,10 @@ export class Campaign {
   }
 
   getCharacterLevel(character: Character) {
-    return this.world!.ruleset.levelProgression.sort((a, b) => a - b).findIndex((l) => l > character.xp);
+    const levelProgression = this.world!.ruleset.levelProgression.slice();
+    const levelInfo = levelProgression.find((l) => l.requiredXp >= character.xp);
+    if (!levelInfo) throw new Error(`Cannot find level progression for xp: ${character.xp}`);
+    return levelInfo.unlocksLevel;
   }
 
   isValidEvent(event: CampaignEventWithRound) {

--- a/packages/roleplayer/src/core/ruleset/ruleset.ts
+++ b/packages/roleplayer/src/core/ruleset/ruleset.ts
@@ -1,12 +1,10 @@
-import { LevelProgression, CharacterStatType, CharacterResourceType } from "../actor/character";
-import { EquipmentSlotDefinition } from "../world/item/item";
 import { DefaultCharacterResourceTypes, DefaultCharacterStatTypes, DefaultEquipmentSlotDefinitions, DefaultLevelProgression } from "../../data/data";
+import { CharacterResourceType, CharacterStatType, LevelProgression } from "../actor/character";
+import { EquipmentSlotDefinition } from "../world/item/item";
 
 export class Ruleset {
   levelProgression: LevelProgression[] = DefaultLevelProgression;
   characterStatTypes: CharacterStatType[] = DefaultCharacterStatTypes;
   characterResourceTypes: CharacterResourceType[] = DefaultCharacterResourceTypes;
   characterEquipmentSlots: EquipmentSlotDefinition[] = DefaultEquipmentSlotDefinitions;
-
-  constructor() {}
 }

--- a/packages/roleplayer/src/data/data.ts
+++ b/packages/roleplayer/src/data/data.ts
@@ -1,8 +1,15 @@
+import { dangerousGenerateId } from "..";
 import { CharacterStatType, LevelProgression } from "../core/actor/character";
 import { Ruleset } from "../core/ruleset/ruleset";
 import { EquipmentSlotDefinition, ItemEquipmentType } from "../core/world/item/item";
 
-export const DefaultLevelProgression: LevelProgression[] = [0, 50, 100, 200, 400];
+export const DefaultLevelProgression: LevelProgression[] = [
+  { requiredXp: 0, id: dangerousGenerateId(), unlocksLevel: 1 },
+  { requiredXp: 50, id: dangerousGenerateId(), unlocksLevel: 2 },
+  { requiredXp: 100, id: dangerousGenerateId(), unlocksLevel: 3 },
+  { requiredXp: 200, id: dangerousGenerateId(), unlocksLevel: 4 },
+  { requiredXp: 400, id: dangerousGenerateId(), unlocksLevel: 5 },
+];
 
 export const DefaultEquipmentSlotDefinitions: EquipmentSlotDefinition[] = [
   {


### PR DESCRIPTION
I've updated the `LevelProgression` type from a `number` to a object containing below properties and refactored the code to work with the new type.

**LevelProgression**
```ts
  id: Id;
  requiredXp: number;
  unlocksLevel: number;
  onLevelUp?: (character: Character, publishEvent: 
```

Also, I've added a test for the `getCharacterLevel` function and updated the web app to work with the new type.